### PR TITLE
Add the capability on using period parameter on measure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   </parent>
   <groupId>com.qualinsight.plugins.sonarqube</groupId>
   <artifactId>qualinsight-plugins-sonarqube-badges</artifactId>
-  <version>3.0.2-SNAPSHOT</version>
+  <version>3.1.0-SNAPSHOT</version>
   <packaging>sonar-plugin</packaging>
   <name>SVG Badges Plugin</name>
   <description>This plugin adds a webservice to SonarQube that allows the retrieval of different types of badges that display as a SVG image the quality of a project or a view.</description>

--- a/src/main/java/com/qualinsight/plugins/sonarqube/badges/ws/measure/MeasureBadgeAction.java
+++ b/src/main/java/com/qualinsight/plugins/sonarqube/badges/ws/measure/MeasureBadgeAction.java
@@ -66,9 +66,13 @@ public class MeasureBadgeAction {
             .setExampleValue("org.codehaus.sonar:sonar")
             .setRequired(true);
         action.createParam("metric")
-            .setDescription("measured metric to be retrieved")
-            .setExampleValue("coverage")
-            .setRequired(true);
+                .setDescription("measured metric to be retrieved")
+                .setExampleValue("coverage")
+                .setRequired(true);
+        action.createParam("period")
+                .setDescription("period of said measure")
+                .setExampleValue("1")
+                .setRequired(false);
         action.createParam("template")
             .setDescription("Template to be used for badge generation")
             .setPossibleValues((Object[]) SVGImageTemplate.values())

--- a/src/main/java/com/qualinsight/plugins/sonarqube/badges/ws/measure/MeasureBadgeMetricNameFormatter.java
+++ b/src/main/java/com/qualinsight/plugins/sonarqube/badges/ws/measure/MeasureBadgeMetricNameFormatter.java
@@ -1,3 +1,22 @@
+/*
+ * qualinsight-plugins-sonarqube-badges
+ * Copyright (c) 2015-2016, QualInsight
+ * http://www.qualinsight.com/
+ *
+ * This program is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation, either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program. If not, you can retrieve a copy
+ * from <http://www.gnu.org/licenses/>.
+ */
 package com.qualinsight.plugins.sonarqube.badges.ws.measure;
 
 import org.slf4j.Logger;
@@ -17,8 +36,9 @@ import java.util.Date;
  * 'previous_version' to compare to the previous version in the project history
  * A version, for example '1.2' or 'BASELINE'
  *
+ * @author WillyPT
  */
-public class MeasureBagdeMetricNameFormatter {
+public class MeasureBadgeMetricNameFormatter {
 
     private static final String PERIOD_DATE_FORMAT = "yyyy-MM-dd";
 
@@ -59,7 +79,7 @@ public class MeasureBagdeMetricNameFormatter {
         return input.equalsIgnoreCase("previous_analysis") || input.equalsIgnoreCase("previous_version");
     }
 
-    private MeasureBagdeMetricNameFormatter () {
+    private MeasureBadgeMetricNameFormatter () {
         throw new IllegalStateException("MeasureBagdeMetricNameFormatter should not be instantiated");
     }
 

--- a/src/main/java/com/qualinsight/plugins/sonarqube/badges/ws/measure/MeasureBadgeRequestHandler.java
+++ b/src/main/java/com/qualinsight/plugins/sonarqube/badges/ws/measure/MeasureBadgeRequestHandler.java
@@ -76,6 +76,7 @@ public class MeasureBadgeRequestHandler implements RequestHandler {
         if (this.settings.getBoolean(BadgesPluginProperties.MEASURE_BADGES_ACTIVATION_KEY)) {
             final String key = request.mandatoryParam("key");
             final String metric = request.mandatoryParam("metric");
+            final int requestedPeriod = request.hasParam("period")? request.paramAsInt("period") : 0;
             final SVGImageTemplate template = request.mandatoryParamAsEnum("template", SVGImageTemplate.class);
             final boolean blinkingValueBackgroundColor = request.mandatoryParamAsBoolean("blinking");
             final WsClient wsClient = WsClientFactories.getLocal()
@@ -83,7 +84,7 @@ public class MeasureBadgeRequestHandler implements RequestHandler {
             LOGGER.debug("Retrieving measure for key '{}' and metric {}.", key, metric);
             MeasureHolder measureHolder;
             try {
-                measureHolder = retrieveMeasureHolder(wsClient, key, metric);
+                measureHolder = retrieveMeasureHolder(wsClient, key, metric, requestedPeriod);
                 measureHolder = applyQualityGateTreshold(wsClient, key, metric, measureHolder);
             } catch (final HttpException e) {
                 LOGGER.debug("No project found with key '{}': {}", key, e);
@@ -105,7 +106,7 @@ public class MeasureBadgeRequestHandler implements RequestHandler {
         }
     }
 
-    private MeasureHolder retrieveMeasureHolder(final WsClient wsClient, final String key, final String metric) {
+    private MeasureHolder retrieveMeasureHolder(final WsClient wsClient, final String key, final String metric, int requestedPeriod) {
         MeasureHolder measureHolder;
         final ComponentWsRequest componentWsRequest = new ComponentWsRequest();
         componentWsRequest.setComponentKey(key);
@@ -117,7 +118,7 @@ public class MeasureBadgeRequestHandler implements RequestHandler {
         if (measures.isEmpty()) {
             measureHolder = new MeasureHolder(metric);
         } else {
-            measureHolder = new MeasureHolder(measures.get(0));
+            measureHolder = new MeasureHolder(measures.get(0), requestedPeriod);
         }
         return measureHolder;
     }

--- a/src/main/java/com/qualinsight/plugins/sonarqube/badges/ws/measure/MeasureBagdeMetricNameFormatter.java
+++ b/src/main/java/com/qualinsight/plugins/sonarqube/badges/ws/measure/MeasureBagdeMetricNameFormatter.java
@@ -17,7 +17,6 @@ import java.util.Date;
  * 'previous_version' to compare to the previous version in the project history
  * A version, for example '1.2' or 'BASELINE'
  *
- * @author WillyPT
  */
 public class MeasureBagdeMetricNameFormatter {
 

--- a/src/main/java/com/qualinsight/plugins/sonarqube/badges/ws/measure/MeasureBagdeMetricNameFormatter.java
+++ b/src/main/java/com/qualinsight/plugins/sonarqube/badges/ws/measure/MeasureBagdeMetricNameFormatter.java
@@ -1,0 +1,84 @@
+package com.qualinsight.plugins.sonarqube.badges.ws.measure;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+/**
+ * Label formatter for Measure badges with added support for Period Index label formatting
+ *
+ * Possible values for period are:
+ * Number of days before analysis, for example 5.
+ * A custom date. Format is yyyy-MM-dd, for example 2010-12-25
+ * 'previous_analysis' to compare to previous analysis
+ * 'previous_version' to compare to the previous version in the project history
+ * A version, for example '1.2' or 'BASELINE'
+ *
+ * @author WillyPT
+ */
+public class MeasureBagdeMetricNameFormatter {
+
+    private static final String PERIOD_DATE_FORMAT = "yyyy-MM-dd";
+
+    private static final String PRINTED_DATE_FORMAT = "dd MMM yyyy";
+
+    private static final String SINCE = " since ";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MeasureHolder.class);
+
+    private static Date getDate(String input) {
+        Date date = null;
+        try {
+            SimpleDateFormat sdf = new SimpleDateFormat(PERIOD_DATE_FORMAT);
+            date = sdf.parse(input);
+            if (!input.equals(sdf.format(date))) {
+                date = null;
+            }
+        } catch (ParseException ex) {
+            LOGGER.debug("Period {} is not a date", input);
+        }
+        return date;
+    }
+
+    private static boolean isDate(String input) {
+        return getDate(input) != null;
+    }
+
+    private static boolean isDays(String input) {
+        try {
+            return Integer.parseInt(input) >= 0;
+        } catch (NumberFormatException e) {
+            LOGGER.debug("Period {} is not a number", input);
+        }
+        return false;
+    }
+
+    private static boolean isPrevious(String input) {
+        return input.equalsIgnoreCase("previous_analysis") || input.equalsIgnoreCase("previous_version");
+    }
+
+    private MeasureBagdeMetricNameFormatter () {
+        throw new IllegalStateException("MeasureBagdeMetricNameFormatter should not be instantiated");
+    }
+
+    public static String getMetricNameWithPeriod(String metricName, String period) {
+        String formattedMetric = metricName.replace(" (%)", "").toLowerCase();
+        if (period != null && period.length() > 0) {
+            if (isPrevious(period)) {
+                formattedMetric = formattedMetric + SINCE + period.replace("_", " ").toLowerCase();
+            } else if (isDays(period)) {
+                formattedMetric = formattedMetric + SINCE + period + " days";
+            } else if (isDate(period)) {
+                SimpleDateFormat sdf = new SimpleDateFormat(PRINTED_DATE_FORMAT);
+                formattedMetric = formattedMetric + SINCE + sdf.format(getDate(period));
+            } else {
+                formattedMetric = formattedMetric + SINCE + period;
+            }
+        }
+        return formattedMetric;
+    }
+
+}

--- a/src/main/java/com/qualinsight/plugins/sonarqube/badges/ws/measure/MeasureHolder.java
+++ b/src/main/java/com/qualinsight/plugins/sonarqube/badges/ws/measure/MeasureHolder.java
@@ -35,7 +35,7 @@ import org.sonarqube.ws.WsMeasures.PeriodValue;
 import org.sonarqube.ws.WsMeasures.PeriodsValue;
 import com.qualinsight.plugins.sonarqube.badges.ws.SVGImageColor;
 
-import static com.qualinsight.plugins.sonarqube.badges.ws.measure.MeasureBagdeMetricNameFormatter.getMetricNameWithPeriod;
+import static com.qualinsight.plugins.sonarqube.badges.ws.measure.MeasureBadgeMetricNameFormatter.getMetricNameWithPeriod;
 
 /**
  * Holds measure badge data.

--- a/src/main/java/com/qualinsight/plugins/sonarqube/badges/ws/measure/MeasureHolder.java
+++ b/src/main/java/com/qualinsight/plugins/sonarqube/badges/ws/measure/MeasureHolder.java
@@ -117,8 +117,8 @@ public class MeasureHolder {
             periodTempValue = this.getPeriodValueByPeriodIndex(measure.getPeriods(), requestedPeriod);
         }
         tempValue = measure.getValue();
-        tempValue = tempValue != null ? valueDf.format(Double.parseDouble(tempValue)) : null;
-        periodTempValue = periodTempValue != null ? periodValueDf.format(Double.parseDouble(periodTempValue)) : null;
+        tempValue = tempValue != null && tempValue.length() > 0 ? valueDf.format(Double.parseDouble(tempValue)) : null;
+        periodTempValue = periodTempValue != null && periodTempValue.length() > 0 ? periodValueDf.format(Double.parseDouble(periodTempValue)) : null;
 
         // Build value
         // If metric has no value, period's value will be treated as value

--- a/src/main/java/com/qualinsight/plugins/sonarqube/badges/ws/measure/MeasureHolder.java
+++ b/src/main/java/com/qualinsight/plugins/sonarqube/badges/ws/measure/MeasureHolder.java
@@ -20,6 +20,8 @@
 package com.qualinsight.plugins.sonarqube.badges.ws.measure;
 
 import java.io.Serializable;
+import java.math.RoundingMode;
+import java.text.DecimalFormat;
 import java.util.NoSuchElementException;
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
@@ -50,6 +52,28 @@ public class MeasureHolder {
     private SVGImageColor backgroundColor = SVGImageColor.GRAY;
 
     /**
+     * Get period value by period index
+     *
+     * @param periods PeriodsValue obtained from {@link Metric}
+     * @param periodIndex Period Index that wants to be obtained. Possible values are 1, 2, or 3.
+     *
+     * @return String of metric value or <i>null</i>
+     */
+    private String getPeriodValueByPeriodIndex(PeriodsValue periods, int periodIndex) {
+        String periodTempValue = null;
+        for (PeriodValue periodvalue : periods.getPeriodsValueList()) {
+            if (periodvalue.hasIndex() && periodvalue.getIndex() == periodIndex) {
+                periodTempValue = periodvalue.getValue();
+                break;
+            }
+        }
+        if (periodTempValue == null) {
+            periodTempValue = periods.getPeriodsValue(0).getValue();
+        }
+        return periodTempValue;
+    }
+
+    /**
      * Constructs a MeasureHolder from a metric key.
      *
      * @param metricKey key used to retrieve the metric name for which the MeasureHolder is built
@@ -71,24 +95,40 @@ public class MeasureHolder {
      * Constructs a MeasureHolder from a Measure object.
      *
      * @param measure used to retrieve the metric name for which the MeasureHolder is built
+     * @param requestedPeriod used to retrieve which period requested for which value will be constructed
      */
     @SuppressWarnings("unchecked")
-    public MeasureHolder(final Measure measure) {
+    public MeasureHolder(final Measure measure, int requestedPeriod) {
+        final DecimalFormat valueDf = new DecimalFormat("#.##");
+        valueDf.setRoundingMode(RoundingMode.CEILING);
+        final DecimalFormat periodValueDf = new DecimalFormat("+#.##;-#.##");
+        periodValueDf.setRoundingMode(RoundingMode.CEILING);
+
         final Metric<Serializable> metric = CoreMetrics.getMetric(measure.getMetric());
         this.metricName = metric.getName()
             .replace(" (%)", "")
             .toLowerCase();
         String tempValue = null;
-        if (!measure.hasValue()) {
-            if (measure.hasPeriods()) {
-                final PeriodsValue periods = measure.getPeriods();
-                final PeriodValue periodValue = periods.getPeriodsValue(0);
-                tempValue = periodValue.getValue();
-            }
-        } else {
-            tempValue = measure.getValue();
+        String periodTempValue = null;
+        if (measure.hasPeriods() && requestedPeriod > 0) {
+            periodTempValue = this.getPeriodValueByPeriodIndex(measure.getPeriods(), requestedPeriod);
         }
-        this.value = tempValue == null ? NA : tempValue + (metric.isPercentageType() ? "%" : "");
+        tempValue = measure.getValue();
+
+        tempValue = tempValue != null ? valueDf.format(Double.parseDouble(tempValue)) : null;
+        periodTempValue = periodTempValue != null ? periodValueDf.format(Double.parseDouble(periodTempValue)) : null;
+
+        // Build value
+        // If metric has no value, period's value will be treated as value
+        // If metric has value, period's value will be treated as delta
+
+        if (tempValue == null) {
+            String percentage = metric.isPercentageType() ? "%" : "";
+            this.value = periodTempValue == null ? NA : periodTempValue + percentage;
+        } else {
+            this.value = tempValue + (metric.isPercentageType() ? "%" : "");
+            this.value = this.value + (periodTempValue != null ? " " + "(" + periodTempValue + ")" : "");
+        }
     }
 
     /**


### PR DESCRIPTION
Right now, measure API doesn't support period. However, we found that period leaks are pretty useful especially if you want to track code coverage or vulnerabilities.

Having them accessible by badges would be amazing.
To use, just append `&period=` on the request in measure bagdes.

Here are some examples I've baked
![screen shot 2017-09-11 at 1 13 32 pm](https://user-images.githubusercontent.com/1708055/30260882-190a866e-96f4-11e7-8b16-69150a0d202d.png)
![screen shot 2017-09-11 at 1 13 21 pm](https://user-images.githubusercontent.com/1708055/30260894-1e7d2e80-96f4-11e7-903b-5ef683d0b1f8.png)
![screen shot 2017-09-11 at 1 13 43 pm](https://user-images.githubusercontent.com/1708055/30260895-1eada448-96f4-11e7-835f-842956d04e1a.png)

👍  amazing plugin! Really helps documentation where accessing Sonarqube from Webservices results in CORS 😄 