### PR TITLE
resolve gitlab badges with project_path variable as key

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   </parent>
   <groupId>com.qualinsight.plugins.sonarqube</groupId>
   <artifactId>qualinsight-plugins-sonarqube-badges</artifactId>
-  <version>3.0.2-SNAPSHOT</version>
+  <version>3.0.3-SNAPSHOT</version>
   <packaging>sonar-plugin</packaging>
   <name>SVG Badges Plugin</name>
   <description>This plugin adds a webservice to SonarQube that allows the retrieval of different types of badges that display as a SVG image the quality of a project or a view.</description>

--- a/src/main/java/com/qualinsight/plugins/sonarqube/badges/ws/GitlabProjectPathKeyResolver.java
+++ b/src/main/java/com/qualinsight/plugins/sonarqube/badges/ws/GitlabProjectPathKeyResolver.java
@@ -1,0 +1,25 @@
+package com.qualinsight.plugins.sonarqube.badges.ws;
+
+import org.apache.commons.lang.StringUtils;
+
+/**
+ * Created by Steven on 2019-01-11.
+ */
+public class GitlabProjectPathKeyResolver {
+
+
+    public static String getGitlabProjectNameByPath(String projectPathAsKey) {
+        if (StringUtils.isEmpty(projectPathAsKey)) {
+            return projectPathAsKey;
+        }
+
+        if (StringUtils.containsAny(projectPathAsKey, "/")) {
+            String[] splits = StringUtils.split(projectPathAsKey, "/");
+            if (splits != null) {
+                return splits[splits.length - 1];
+            }
+        }
+
+        return projectPathAsKey;
+    }
+}

--- a/src/main/java/com/qualinsight/plugins/sonarqube/badges/ws/ce/CeActivityBadgeAction.java
+++ b/src/main/java/com/qualinsight/plugins/sonarqube/badges/ws/ce/CeActivityBadgeAction.java
@@ -75,6 +75,11 @@ public class CeActivityBadgeAction {
             .setBooleanPossibleValues()
             .setDefaultValue(Boolean.FALSE)
             .setRequired(false);
+        action.createParam("gitlab")
+                .setDescription("Set to 'true' if you want to using it at gitlab badges.")
+                .setBooleanPossibleValues()
+                .setDefaultValue(Boolean.FALSE)
+                .setRequired(false);
     }
 
 }

--- a/src/main/java/com/qualinsight/plugins/sonarqube/badges/ws/gate/QualityGateBadgeAction.java
+++ b/src/main/java/com/qualinsight/plugins/sonarqube/badges/ws/gate/QualityGateBadgeAction.java
@@ -75,5 +75,10 @@ public class QualityGateBadgeAction {
             .setBooleanPossibleValues()
             .setDefaultValue(Boolean.FALSE)
             .setRequired(false);
+        action.createParam("gitlab")
+                .setDescription("Set to 'true' if you want to using it at gitlab badges.")
+                .setBooleanPossibleValues()
+                .setDefaultValue(Boolean.FALSE)
+                .setRequired(false);
     }
 }

--- a/src/main/java/com/qualinsight/plugins/sonarqube/badges/ws/measure/MeasureBadgeAction.java
+++ b/src/main/java/com/qualinsight/plugins/sonarqube/badges/ws/measure/MeasureBadgeAction.java
@@ -79,5 +79,10 @@ public class MeasureBadgeAction {
             .setBooleanPossibleValues()
             .setDefaultValue(Boolean.FALSE)
             .setRequired(false);
+        action.createParam("gitlab")
+                .setDescription("Set to 'true' if you want to using it at gitlab badges.")
+                .setBooleanPossibleValues()
+                .setDefaultValue(Boolean.FALSE)
+                .setRequired(false);
     }
 }


### PR DESCRIPTION
  [Gitlab support group badges](https://docs.gitlab.com/ee/user/project/badges.html#doc-nav) but only has 4 variables.

We have several projects under group, like 'Server/aaa-service', 'Server/bbb-service','Server/middleware/ccc-service'.

Gitlab only give us project_path but we want get project_name which are same as sonarQube project key. And Sonarqube does not support '/' as one of project key yet. We also do not want to set badges as project level. 

So I add a parameter called 'gitlab', when pass it to 'ture',  the 'key' will split with '/' and get the last node as project key. It is quite simple.

So I will give some examples:

`https://sonar.example.com/api/badges/measure?key=Server/aaa-service&metric=coverage&gitlab=true` -> `https://sonar.example.com?id=aaa-service`

`https://sonar.example.com/api/badges/measure?key=Server/Subgroup/aaa-service&metric=coverage&gitlab=true` -> `https://sonar.example.com?id=aaa-service`